### PR TITLE
Complete transition away from `'cl`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,14 +24,13 @@ WORK_DIR=$(shell pwd)
 PACKAGE_NAME=$(shell basename $(WORK_DIR))
 PACKAGE_VERSION=$(shell perl -ne 'print "$$1\n" if m{^;+ *Version: *(\S+)}' $(PACKAGE_NAME).el)
 AUTOLOADS_FILE=$(PACKAGE_NAME)-autoloads.el
-TRAVIS_FILE=.travis.yml
 TEST_DIR=ert-tests
 TEST_DEP_1=ert
 TEST_DEP_1_STABLE_URL=http://git.savannah.gnu.org/cgit/emacs.git/plain/lisp/emacs-lisp/ert.el?h=emacs-24.3
 TEST_DEP_1_LATEST_URL=http://git.savannah.gnu.org/cgit/emacs.git/plain/lisp/emacs-lisp/ert.el?h=master
 
 .PHONY : build dist not-dirty pkg-version downloads downloads-latest autoloads \
- test-autoloads test-travis test test-prep test-batch test-interactive         \
+ test-autoloads test test-prep test-batch test-interactive                     \
  test-tests clean edit run-pristine run-pristine-local upload-github           \
  upload-wiki upload-marmalade test-dep-1 test-dep-2 test-dep-3 test-dep-4      \
  test-dep-5 test-dep-6 test-dep-7 test-dep-8 test-dep-9
@@ -39,7 +38,6 @@ TEST_DEP_1_LATEST_URL=http://git.savannah.gnu.org/cgit/emacs.git/plain/lisp/emac
 build :
 	$(EMACS) $(EMACS_BATCH) --eval    \
 	    "(progn                                \
-	      (setq byte-compile-error-on-warn t)  \
 	      (batch-byte-compile))" *.el
 
 not-dirty :
@@ -73,18 +71,15 @@ test-autoloads : autoloads
 	@$(EMACS) $(EMACS_BATCH) -L . -l './$(AUTOLOADS_FILE)' || \
 	 ( echo "failed to load autoloads: $(AUTOLOADS_FILE)" && false )
 
-test-travis :
-	@if test -z "$$TRAVIS" && test -e '$(TRAVIS_FILE)'; then travis-lint '$(TRAVIS_FILE)'; fi
-
 test-tests :
 	@perl -ne 'if (m/^\s*\(\s*ert-deftest\s*(\S+)/) {die "$$1 test name duplicated in $$ARGV\n" if $$dupes{$$1}++}' '$(TEST_DIR)/'*-test.el
 
-test-prep : build test-dep-1 test-autoloads test-travis test-tests
+test-prep : build test-dep-1 test-autoloads test-tests
 
 test-batch :
 	@cd '$(TEST_DIR)'                                 && \
 	(for test_lib in *-test.el; do                       \
-	   $(EMACS) $(EMACS_BATCH) -L . -L .. -l cl \
+	   $(EMACS) $(EMACS_BATCH) -L . -L .. -l cl-macs      \
 	   -l '$(TEST_DEP_1)' -l "$$test_lib" --eval         \
 	    "(progn                                          \
 	      (fset 'ert--print-backtrace 'ignore)           \
@@ -100,7 +95,7 @@ test-interactive : test-prep
 	      (setq dired-use-ls-dired nil)                              \
 	      (setq frame-title-format \"TEST SESSION $$test_lib\")      \
 	      (setq enable-local-variables :safe))"                      \
-	    -L . -L .. -l cl -l '$(TEST_DEP_1)' -l "$$test_lib"          \
+	    -L . -L .. -l cl-macs -l '$(TEST_DEP_1)' -l "$$test_lib"      \
 	    --visit "$$test_lib" --eval                                  \
 	    "(progn                                                      \
 	      (when (> (length \"$(TESTS)\") 0)                          \

--- a/ert-tests/list-utils-test.el
+++ b/ert-tests/list-utils-test.el
@@ -1,5 +1,6 @@
 (require 'list-utils)
 (require 'cl-seq)
+(require 'cl-macs)
 
 ;;; utility functions for testing
 
@@ -10,11 +11,11 @@
 ;;; make-tconc
 
 (ert-deftest make-tconc-01 nil
-  (should (equal '[cl-struct-tconc nil nil]
+  (should (equal #s(tconc nil nil)
                  (make-tconc))))
 
 (ert-deftest make-tconc-02 nil
-  (should (equal '[cl-struct-tconc (1 2 3) (3)]
+  (should (equal #s(tconc (1 2 3) (3))
                  (let ((lst '(1 2 3)))
                    (make-tconc :head lst :tail (last lst))))))
 
@@ -28,7 +29,7 @@
                    (tconc-list tc '(4 5))))))
 
 (ert-deftest tconc-list-02 nil
-  (should (equal '[cl-struct-tconc (1 2 3 4 5) (5)]
+  (should (equal #s(tconc (1 2 3 4 5) (5))
                  (let ((tc (make-tconc)))
                    (tconc-list tc '(1 2 3))
                    (tconc-list tc '(4 5))
@@ -44,7 +45,7 @@
                    (tconc tc 4 5)))))
 
 (ert-deftest tconc-02 nil
-  (should (equal '[cl-struct-tconc (1 2 3 4 5) (5)]
+  (should (equal #s(tconc (1 2 3 4 5) (5))
                  (let ((tc (make-tconc)))
                    (tconc tc 1 2 3)
                    (tconc tc 4 5)
@@ -95,13 +96,14 @@
 
 (ert-deftest list-utils-make-proper-copy-03 nil
   "Non-list"
-  (should-error
-   (list-utils-make-proper-copy 1)))
+  (let ((debug-on-error nil))
+    (should-error
+     (list-utils-make-proper-copy 1))))
 
 (ert-deftest list-utils-make-proper-copy-04 nil
   "Two elt cons"
   (let* ((proper '(1 2))
-         (improper (apply 'list* proper))
+         (improper (apply 'cl-list* proper))
          (backup (copy-tree improper)))
     (should-not
      (equal proper improper))
@@ -115,7 +117,7 @@
 (ert-deftest list-utils-make-proper-copy-05 nil
   "Multi-elt improper list"
   (let* ((proper '(a b c d e f))
-         (improper (apply 'list* proper))
+         (improper (apply 'cl-list* proper))
          (backup (copy-tree improper)))
     (should-not
      (equal proper improper))
@@ -157,13 +159,14 @@
 
 (ert-deftest list-utils-make-proper-copy-09 nil
   "With 'tree. Non-list"
-  (should-error
-   (list-utils-make-proper-copy 1)))
+  (let ((debug-on-error nil))
+    (should-error
+     (list-utils-make-proper-copy 1))))
 
 (ert-deftest list-utils-make-proper-copy-10 nil
   "With 'tree. Two elt cons"
   (let* ((proper '(1 2))
-         (improper (apply 'list* proper))
+         (improper (apply 'cl-list* proper))
          (backup (copy-tree improper)))
     (should-not
      (equal proper improper))
@@ -177,7 +180,7 @@
 (ert-deftest list-utils-make-proper-copy-11 nil
   "With 'tree. Multi-elt improper list"
   (let* ((proper '(a b c d e f))
-         (improper (apply 'list* proper))
+         (improper (apply 'cl-list* proper))
          (backup (copy-tree improper)))
     (should-not
      (equal proper improper))
@@ -236,13 +239,14 @@
 
 (ert-deftest list-utils-make-proper-inplace-03 nil
   "Non-list"
-  (should-error
-   (list-utils-make-proper-inplace 1)))
+  (let ((debug-on-error nil))
+    (should-error
+     (list-utils-make-proper-inplace 1))))
 
 (ert-deftest list-utils-make-proper-inplace-04 nil
   "Two elt cons"
   (let* ((proper '(1 2))
-         (improper (apply 'list* proper)))
+         (improper (apply 'cl-list* proper)))
     (should-not
      (equal proper improper))
     (should
@@ -255,7 +259,7 @@
 (ert-deftest list-utils-make-proper-inplace-05 nil
   "Multi-elt improper list"
   (let* ((proper '(a b c d e f))
-         (improper (apply 'list* proper)))
+         (improper (apply 'cl-list* proper)))
     (should-not
      (equal proper improper))
     (should
@@ -296,13 +300,14 @@
 
 (ert-deftest list-utils-make-proper-inplace-09 nil
   "With 'tree. Non-list"
-  (should-error
-   (list-utils-make-proper-inplace 1 'tree)))
+  (let ((debug-on-error nil))
+    (should-error
+     (list-utils-make-proper-inplace 1 'tree))))
 
 (ert-deftest list-utils-make-proper-inplace-10 nil
   "With 'tree. Two elt cons"
   (let* ((proper '(1 2))
-         (improper (apply 'list* proper)))
+         (improper (apply 'cl-list* proper)))
     (should-not
      (equal proper improper))
     (should
@@ -315,7 +320,7 @@
 (ert-deftest list-utils-make-proper-inplace-11 nil
   "With 'tree. Multi-elt improper list"
   (let* ((proper '(a b c d e f))
-         (improper (apply 'list* proper)))
+         (improper (apply 'cl-list* proper)))
     (should-not
      (equal proper improper))
     (should
@@ -367,18 +372,20 @@
 
 (ert-deftest list-utils-make-improper-copy-02 nil
   "Nil"
-  (should-error
-   (list-utils-make-improper-copy nil)))
+  (let ((debug-on-error nil))
+    (should-error
+     (list-utils-make-improper-copy nil))))
 
 (ert-deftest list-utils-make-improper-copy-03 nil
   "Non-list"
-  (should-error
-   (list-utils-make-improper-copy 1)))
+  (let ((debug-on-error nil))
+    (should-error
+     (list-utils-make-improper-copy 1))))
 
 (ert-deftest list-utils-make-improper-copy-04 nil
   "Two elt list"
   (let* ((proper '(1 2))
-         (improper (apply 'list* proper))
+         (improper (apply 'cl-list* proper))
          (backup (copy-tree proper)))
     (should-not
      (equal improper proper))
@@ -392,7 +399,7 @@
 (ert-deftest list-utils-make-improper-copy-05 nil
   "Multi-elt list"
   (let* ((proper '(a b c d e f))
-         (improper (apply 'list* proper))
+         (improper (apply 'cl-list* proper))
          (backup (copy-tree proper)))
     (should-not
      (equal improper proper))
@@ -409,8 +416,9 @@
          (copy (copy-tree proper)))
     (should
      (equal proper copy))
-    (should-error
-     (list-utils-make-improper-copy copy))))
+    (let ((debug-on-error nil))
+      (should-error
+       (list-utils-make-improper-copy copy)))))
 
 (ert-deftest list-utils-make-improper-copy-07 nil
   "With 'tree. Already improper"
@@ -426,18 +434,20 @@
 
 (ert-deftest list-utils-make-improper-copy-08 nil
   "With 'tree. Nil"
-  (should-error
-   (list-utils-make-improper-copy nil 'tree)))
+  (let ((debug-on-error nil))
+    (should-error
+     (list-utils-make-improper-copy nil 'tree))))
 
 (ert-deftest list-utils-make-improper-copy-09 nil
   "With 'tree. Non-list"
-  (should-error
-   (list-utils-make-improper-copy 1 'tree)))
+  (let ((debug-on-error nil))
+    (should-error
+     (list-utils-make-improper-copy 1 'tree))))
 
 (ert-deftest list-utils-make-improper-copy-10 nil
   "With 'tree. Two elt list"
   (let* ((proper '(1 2))
-         (improper (apply 'list* proper))
+         (improper (apply 'cl-list* proper))
          (backup (copy-tree proper)))
     (should-not
      (equal improper proper))
@@ -451,7 +461,7 @@
 (ert-deftest list-utils-make-improper-copy-11 nil
   "With 'tree. Multi-elt list"
   (let* ((proper '(a b c d e f))
-         (improper (apply 'list* proper))
+         (improper (apply 'cl-list* proper))
          (backup (copy-tree proper)))
     (should-not
      (equal improper proper))
@@ -468,8 +478,9 @@
          (copy (copy-tree proper)))
     (should
      (equal proper copy))
-    (should-error
-     (list-utils-make-improper-copy copy 'tree))))
+    (let ((debug-on-error nil))
+      (should-error
+       (list-utils-make-improper-copy copy 'tree)))))
 
 (ert-deftest list-utils-make-improper-copy-13 nil
   "With 'tree. Deep structure."
@@ -502,18 +513,20 @@
 
 (ert-deftest list-utils-make-improper-inplace-02 nil
   "Nil"
-  (should-error
-   (list-utils-make-improper-inplace nil)))
+  (let ((debug-on-error nil))
+    (should-error
+     (list-utils-make-improper-inplace nil))))
 
 (ert-deftest list-utils-make-improper-inplace-03 nil
   "Non-list"
-  (should-error
-   (list-utils-make-improper-inplace 1)))
+  (let ((debug-on-error nil))
+    (should-error
+     (list-utils-make-improper-inplace 1))))
 
 (ert-deftest list-utils-make-improper-inplace-04 nil
   "Two elt list"
   (let* ((proper '(1 2))
-         (improper (apply 'list* proper)))
+         (improper (apply 'cl-list* proper)))
     (should-not
      (equal improper proper))
     (should
@@ -526,7 +539,7 @@
 (ert-deftest list-utils-make-improper-inplace-05 nil
   "Multi-elt list"
   (let* ((proper '(a b c d e f))
-         (improper (apply 'list* proper)))
+         (improper (apply 'cl-list* proper)))
     (should-not
      (equal improper proper))
     (should
@@ -542,8 +555,9 @@
          (copy (copy-tree proper)))
     (should
      (equal proper copy))
-    (should-error
-     (list-utils-make-improper-inplace copy))))
+    (let ((debug-on-error nil))
+      (should-error
+       (list-utils-make-improper-inplace copy)))))
 
 (ert-deftest list-utils-make-improper-inplace-07 nil
   "With 'tree. Already improper"
@@ -559,18 +573,20 @@
 
 (ert-deftest list-utils-make-improper-inplace-08 nil
   "With 'tree. Nil"
-  (should-error
-   (list-utils-make-improper-inplace nil 'tree)))
+  (let ((debug-on-error nil))
+    (should-error
+     (list-utils-make-improper-inplace nil 'tree))))
 
 (ert-deftest list-utils-make-improper-inplace-09 nil
   "With 'tree. Non-list"
-  (should-error
-   (list-utils-make-improper-inplace 1 'tree)))
+  (let ((debug-on-error nil))
+    (should-error
+     (list-utils-make-improper-inplace 1 'tree))))
 
 (ert-deftest list-utils-make-improper-inplace-10 nil
   "With 'tree. Two elt list"
   (let* ((proper '(1 2))
-         (improper (apply 'list* proper)))
+         (improper (apply 'cl-list* proper)))
     (should-not
      (equal improper proper))
     (should
@@ -583,7 +599,7 @@
 (ert-deftest list-utils-make-improper-inplace-11 nil
   "With 'tree. Multi-elt list"
   (let* ((proper '(a b c d e f))
-         (improper (apply 'list* proper)))
+         (improper (apply 'cl-list* proper)))
     (should-not
      (equal improper proper))
     (should
@@ -599,8 +615,9 @@
          (copy (copy-tree proper)))
     (should
      (equal proper copy))
-    (should-error
-     (list-utils-make-improper-inplace copy 'tree))))
+    (let ((debug-on-error nil))
+      (should-error
+       (list-utils-make-improper-inplace copy 'tree)))))
 
 (ert-deftest list-utils-make-improper-inplace-13 nil
   "With 'tree. Deep structure."
@@ -642,7 +659,7 @@
 
 (ert-deftest list-utils-cyclic-length-05 nil
   (should (= 0
-             (list-utils-cyclic-length (list* 1 2 3)))))
+             (list-utils-cyclic-length (cl-list* 1 2 3)))))
 
 (ert-deftest list-utils-cyclic-length-06 nil
   (let ((cyclic '(1)))
@@ -691,7 +708,7 @@
 
 (ert-deftest list-utils-cyclic-subseq-08 nil
   (should-not
-   (list-utils-cyclic-subseq (list* 1 2 3))))
+   (list-utils-cyclic-subseq (cl-list* 1 2 3))))
 
 (ert-deftest list-utils-cyclic-subseq-09 nil
   (let ((cyclic '(1)))
@@ -747,7 +764,7 @@
 
 (ert-deftest list-utils-cyclic-p-09 nil
   (should-not
-   (list-utils-cyclic-p (list* 1 2 3))))
+   (list-utils-cyclic-p (cl-list* 1 2 3))))
 
 (ert-deftest list-utils-cyclic-p-10 nil
   (should
@@ -790,7 +807,7 @@
 
 (ert-deftest list-utils-linear-p-07 nil
   (should
-   (list-utils-linear-p (list* 1 2 3))))
+   (list-utils-linear-p (cl-list* 1 2 3))))
 
 (ert-deftest list-utils-linear-p-08 nil
   (let ((cyclic '(1)))
@@ -825,9 +842,9 @@
                    (list-utils-linear-subseq improper)))))
 
 (ert-deftest list-utils-linear-subseq-05 nil
-  (let ((improper (list* 1 2 3)))
+  (let ((improper (cl-list* 1 2 3)))
     (should (equal improper
-                   (list-utils-linear-subseq (list* 1 2 3))))))
+                   (list-utils-linear-subseq (cl-list* 1 2 3))))))
 
 (ert-deftest list-utils-linear-subseq-06 nil
   (let ((cyclic '(1)))
@@ -875,7 +892,7 @@
 
 (ert-deftest list-utils-safe-length-08 nil
   (should (= 2
-             (list-utils-safe-length (list* 1 2 3)))))
+             (list-utils-safe-length (cl-list* 1 2 3)))))
 
 (ert-deftest list-utils-safe-length-09 nil
   (let ((cyclic '(1)))
@@ -1200,7 +1217,7 @@
 
 (ert-deftest list-utils-safe-equal-10 nil
   "Improper list"
-  (let* ((value (list* 1 2 3))
+  (let* ((value (cl-list* 1 2 3))
          (copy-1 (copy-tree value))
          (copy-2 (copy-tree value)))
     (should
@@ -1210,15 +1227,15 @@
 
 (ert-deftest list-utils-safe-equal-11 nil
   "Improper list"
-  (let* ((value-1 (list* 1 2 3))
-         (value-2 (list* 1 2)))
+  (let* ((value-1 (cl-list* 1 2 3))
+         (value-2 (cl-list* 1 2)))
     (should-not
      (list-utils-safe-equal value-1 value-2))))
 
 (ert-deftest list-utils-safe-equal-12 nil
   "Improper list"
-  (let* ((value-1 (list* 1 2 3))
-         (value-2 (list* 1 2 4)))
+  (let* ((value-1 (cl-list* 1 2 3))
+         (value-2 (cl-list* 1 2 4)))
     (should-not
      (list-utils-safe-equal value-1 value-2))))
 
@@ -1285,8 +1302,8 @@
             (list-utils-linear-subseq cyclic-2)))
     (should
      (equal
-      (subseq (list-utils-cyclic-subseq cyclic-1) 0 (list-utils-safe-length (list-utils-cyclic-subseq cyclic-1)))
-      (subseq (list-utils-cyclic-subseq cyclic-2) 0 (list-utils-safe-length (list-utils-cyclic-subseq cyclic-2)))))))
+      (cl-subseq (list-utils-cyclic-subseq cyclic-1) 0 (list-utils-safe-length (list-utils-cyclic-subseq cyclic-1)))
+      (cl-subseq (list-utils-cyclic-subseq cyclic-2) 0 (list-utils-safe-length (list-utils-cyclic-subseq cyclic-2)))))))
 
 
 ;;; list-utils-depth
@@ -1372,8 +1389,8 @@
             (list-utils-linear-subseq cyclic-2)))
     (should
      (equal
-      (subseq (list-utils-cyclic-subseq cyclic-1) 0 (list-utils-safe-length (list-utils-cyclic-subseq cyclic-1)))
-      (subseq (list-utils-cyclic-subseq cyclic-2) 0 (list-utils-safe-length (list-utils-cyclic-subseq cyclic-2)))))))
+      (cl-subseq (list-utils-cyclic-subseq cyclic-1) 0 (list-utils-safe-length (list-utils-cyclic-subseq cyclic-1)))
+      (cl-subseq (list-utils-cyclic-subseq cyclic-2) 0 (list-utils-safe-length (list-utils-cyclic-subseq cyclic-2)))))))
 
 
 ;;; list-utils-alist-or-flat-length
@@ -1420,8 +1437,8 @@
             (list-utils-linear-subseq cyclic-2)))
     (should
      (equal
-      (subseq (list-utils-cyclic-subseq cyclic-1) 0 (list-utils-safe-length (list-utils-cyclic-subseq cyclic-1)))
-      (subseq (list-utils-cyclic-subseq cyclic-2) 0 (list-utils-safe-length (list-utils-cyclic-subseq cyclic-2)))))))
+      (cl-subseq (list-utils-cyclic-subseq cyclic-1) 0 (list-utils-safe-length (list-utils-cyclic-subseq cyclic-1)))
+      (cl-subseq (list-utils-cyclic-subseq cyclic-2) 0 (list-utils-safe-length (list-utils-cyclic-subseq cyclic-2)))))))
 
 
 ;;; list-utils-insert-before
@@ -1439,29 +1456,31 @@
                  (list-utils-insert-before '(1 2 3 4 5) 5 'elt))))
 
 (ert-deftest list-utils-insert-before-04 nil
-  (should-error
-   (list-utils-insert-before '(1 2 3 4 5) 6 'elt)))
+  (let ((debug-on-error nil))
+    (should-error
+     (list-utils-insert-before '(1 2 3 4 5) 6 'elt))))
 
 (ert-deftest list-utils-insert-before-05 nil
-  (should (equal (list* 'elt 1 2)
+  (should (equal (cl-list* 'elt 1 2)
              (list-utils-insert-before (cons 1 2) 1 'elt))))
 
 (ert-deftest list-utils-insert-before-06 nil
-  (should (equal (list* 1 'elt 2)
+  (should (equal (cl-list* 1 'elt 2)
                  (list-utils-insert-before (cons 1 2) 2 'elt))))
 
 (ert-deftest list-utils-insert-before-07 nil
-  (should (equal (list* 1 'elt 2 3)
-                 (list-utils-insert-before (list* 1 2 3) 2 'elt))))
+  (should (equal (cl-list* 1 'elt 2 3)
+                 (list-utils-insert-before (cl-list* 1 2 3) 2 'elt))))
 
 (ert-deftest list-utils-insert-before-08 nil
-  (should (equal (list* 1 2 'elt 3)
-                 (list-utils-insert-before (list* 1 2 3) 3 'elt))))
+  (should (equal (cl-list* 1 2 'elt 3)
+                 (list-utils-insert-before (cl-list* 1 2 3) 3 'elt))))
 
 (ert-deftest list-utils-insert-before-09 nil
   "set TEST"
-  (should-error
-   (list-utils-insert-before '(1 2.0 3 4 5) 2 'elt))
+  (let ((debug-on-error nil))
+    (should-error
+     (list-utils-insert-before '(1 2.0 3 4 5) 2 'elt)))
   (should
    (equal '(1 elt 2.0 3 4 5)
           (list-utils-insert-before '(1 2.0 3 4 5) 2 'elt '=))))
@@ -1482,29 +1501,31 @@
                  (list-utils-insert-after '(1 2 3 4 5) 5 'elt))))
 
 (ert-deftest list-utils-insert-after-04 nil
-  (should-error
-   (list-utils-insert-after '(1 2 3 4 5) 6 'elt)))
+  (let ((debug-on-error nil))
+    (should-error
+     (list-utils-insert-after '(1 2 3 4 5) 6 'elt))))
 
 (ert-deftest list-utils-insert-after-05 nil
-  (should (equal (list* 1 'elt 2)
+  (should (equal (cl-list* 1 'elt 2)
                  (list-utils-insert-after (cons 1 2) 1 'elt))))
 
 (ert-deftest list-utils-insert-after-06 nil
-  (should (equal (list* 1 2 'elt)
+  (should (equal (cl-list* 1 2 'elt)
                  (list-utils-insert-after (cons 1 2) 2 'elt))))
 
 (ert-deftest list-utils-insert-after-07 nil
-  (should (equal (list* 1 2 'elt 3)
-                 (list-utils-insert-after (list* 1 2 3) 2 'elt))))
+  (should (equal (cl-list* 1 2 'elt 3)
+                 (list-utils-insert-after (cl-list* 1 2 3) 2 'elt))))
 
 (ert-deftest list-utils-insert-after-08 nil
-  (should (equal (list* 1 2 3 'elt)
-                 (list-utils-insert-after (list* 1 2 3) 3 'elt))))
+  (should (equal (cl-list* 1 2 3 'elt)
+                 (list-utils-insert-after (cl-list* 1 2 3) 3 'elt))))
 
 (ert-deftest list-utils-insert-after-09 nil
   "set TEST"
-  (should-error
-   (list-utils-insert-after '(1 2.0 3 4 5) 2 'elt))
+  (let ((debug-on-error nil))
+    (should-error
+     (list-utils-insert-after '(1 2.0 3 4 5) 2 'elt)))
   (should
    (equal '(1 2.0 elt 3 4 5)
           (list-utils-insert-after '(1 2.0 3 4 5) 2 'elt '=))))
@@ -1525,32 +1546,35 @@
                  (list-utils-insert-before-pos '(a b c d e) 4 'elt))))
 
 (ert-deftest list-utils-insert-before-pos-04 nil
-  (should-error
-   (list-utils-insert-before-pos '(a b c d e) 5 'elt)))
+  (let ((debug-on-error nil))
+    (should-error
+     (list-utils-insert-before-pos '(a b c d e) 5 'elt))))
 
 (ert-deftest list-utils-insert-before-pos-05 nil
-  (should (equal (list* 'elt 1 2)
+  (should (equal (cl-list* 'elt 1 2)
                  (list-utils-insert-before-pos (cons 1 2) 0 'elt))))
 
 (ert-deftest list-utils-insert-before-pos-06 nil
-  (should (equal (list* 1 'elt 2)
+  (should (equal (cl-list* 1 'elt 2)
                  (list-utils-insert-before-pos (cons 1 2) 1 'elt))))
 
 (ert-deftest list-utils-insert-before-pos-07 nil
-  (should-error
-   (list-utils-insert-before-pos (cons 1 2) 2 'elt)))
+  (let ((debug-on-error nil))
+    (should-error
+     (list-utils-insert-before-pos (cons 1 2) 2 'elt))))
 
 (ert-deftest list-utils-insert-before-pos-08 nil
-  (should (equal (list* 1 'elt 2 3)
-                 (list-utils-insert-before-pos (list* 1 2 3) 1 'elt))))
+  (should (equal (cl-list* 1 'elt 2 3)
+                 (list-utils-insert-before-pos (cl-list* 1 2 3) 1 'elt))))
 
 (ert-deftest list-utils-insert-before-pos-09 nil
-  (should (equal (list* 1 2 'elt 3)
-                 (list-utils-insert-before-pos (list* 1 2 3) 2 'elt))))
+  (should (equal (cl-list* 1 2 'elt 3)
+                 (list-utils-insert-before-pos (cl-list* 1 2 3) 2 'elt))))
 
 (ert-deftest list-utils-insert-before-pos-10 nil
-  (should-error
-   (list-utils-insert-before-pos (list* 1 2 3) 3 'elt)))
+  (let ((debug-on-error nil))
+    (should-error
+     (list-utils-insert-before-pos (cl-list* 1 2 3) 3 'elt))))
 
 
 ;;; list-utils-insert-after-pos
@@ -1568,32 +1592,35 @@
                  (list-utils-insert-after-pos '(a b c d e) 4 'elt))))
 
 (ert-deftest list-utils-insert-after-pos-04 nil
-  (should-error
-   (list-utils-insert-after-pos '(a b c d e) 5 'elt)))
+  (let ((debug-on-error nil))
+    (should-error
+     (list-utils-insert-after-pos '(a b c d e) 5 'elt))))
 
 (ert-deftest list-utils-insert-after-pos-05 nil
-  (should (equal (list* 1 'elt 2)
+  (should (equal (cl-list* 1 'elt 2)
                  (list-utils-insert-after-pos (cons 1 2) 0 'elt))))
 
 (ert-deftest list-utils-insert-after-pos-06 nil
-  (should (equal (list* 1 2 'elt)
+  (should (equal (cl-list* 1 2 'elt)
                  (list-utils-insert-after-pos (cons 1 2) 1 'elt))))
 
 (ert-deftest list-utils-insert-after-pos-07 nil
-  (should-error
-   (list-utils-insert-after-pos (cons 1 2) 2 'elt)))
+  (let ((debug-on-error nil))
+    (should-error
+     (list-utils-insert-after-pos (cons 1 2) 2 'elt))))
 
 (ert-deftest list-utils-insert-after-pos-08 nil
-  (should (equal (list* 1 2 'elt 3)
-                 (list-utils-insert-after-pos (list* 1 2 3) 1 'elt))))
+  (should (equal (cl-list* 1 2 'elt 3)
+                 (list-utils-insert-after-pos (cl-list* 1 2 3) 1 'elt))))
 
 (ert-deftest list-utils-insert-after-pos-09 nil
-  (should (equal (list* 1 2 3 'elt)
-                 (list-utils-insert-after-pos (list* 1 2 3) 2 'elt))))
+  (should (equal (cl-list* 1 2 3 'elt)
+                 (list-utils-insert-after-pos (cl-list* 1 2 3) 2 'elt))))
 
 (ert-deftest list-utils-insert-after-pos-10 nil
-  (should-error
-   (list-utils-insert-after-pos (list* 1 2 3) 3 'elt)))
+  (let ((debug-on-error nil))
+    (should-error
+     (list-utils-insert-after-pos (cl-list* 1 2 3) 3 'elt))))
 
 
 ;;; list-utils-and
@@ -2251,8 +2278,9 @@
                  (list-utils-plist-reverse '(:one 1 :two 2 :three 3 :four 4)))))
 
 (ert-deftest list-utils-plist-reverse-02 nil
-  (should-error
-   (list-utils-plist-reverse '(:one 1 :two 2 :three 3 :four))))
+  (let ((debug-on-error nil))
+    (should-error
+     (list-utils-plist-reverse '(:one 1 :two 2 :three 3 :four)))))
 
 (ert-deftest list-utils-plist-reverse-03 nil
   (should (equal '(:four 4 :three 3 :two 2 :one (1 (1 (1))))

--- a/list-utils.el
+++ b/list-utils.el
@@ -120,7 +120,7 @@
 ;;     could do -copy/-inplace variants for more functions, consider doing
 ;;     so for flatten
 ;;
-;;     list* returns a non-list on single elt, our function throws an error
+;;     cl-list* returns a non-list on single elt, our function throws an error
 ;;
 ;;; License
 ;;
@@ -256,7 +256,7 @@ A hash-table-test is defined with the same name."
 
 ;;;###autoload
 (progn
-  (require 'cl)
+  (require 'cl-macs)
   (cl-defstruct tconc head tail))
 
 ;;;###autoload
@@ -305,7 +305,7 @@ elements, eg
 
     '(1 2 3 4 . 5)
 
-Such improper lists are produced by `list*'."
+Such improper lists are produced by `cl-list*'."
   (let ((len (safe-length cell)))
     (when (and (consp cell)
                (> len 0)
@@ -322,7 +322,7 @@ copies of any improper lists contained within.
 Optional RECUR-INTERNAL is for internal use only.
 
 Improper lists consist of proper lists consed to a final
-element, and are produced by `list*'."
+element, and are produced by `cl-list*'."
   (cl-assert (or recur-internal (listp list)) nil "LIST is not a list")
   (cond
     ((not tree)
@@ -346,7 +346,7 @@ element, and are produced by `list*'."
   "Make a cons cell or improper LIST into a proper list.
 
 Improper lists consist of proper lists consed to a final
-element, and are produced by `list*'.
+element, and are produced by `cl-list*'.
 
 If optional TREE is non-nil, traverse LIST, making any
 improper lists contained within into proper lists.
@@ -373,7 +373,7 @@ Modifies LIST and returns the modified value."
   "Copy a proper LIST into an improper list.
 
 Improper lists consist of proper lists consed to a final
-element, and are produced by `list*'.
+element, and are produced by `cl-list*'.
 
 If optional TREE is non-nil, traverse LIST, making proper
 copies of any improper lists contained within.
@@ -403,7 +403,7 @@ Optional RECUR-INTERNAL is for internal use only."
   "Make proper LIST into an improper list.
 
 Improper lists consist of proper lists consed to a final
-element, and are produced by `list*'.
+element, and are produced by `cl-list*'.
 
 If optional TREE is non-nil, traverse LIST, making any
 proper lists contained within into improper lists.


### PR DESCRIPTION
Incidentally removing some Travis cruft from the Makefile.

Closes #6.  This probably makes the library stop working on older Emacs versions, which is not tested.